### PR TITLE
Get basic responsive features

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -95,5 +95,36 @@ $(document).ready(function () {
   $("#zoom_04c").elevateZoom({zoomWindowPosition: "demo-container", zoomWindowHeight: 200, zoomWindowWidth:200, borderSize: 0, easing:true}); 
 </script>
 
+<hr />
+
+<h1>Screen-size sesitivity</h1>
+
+<p>
+  Not truly responsive yet, since it goes based off the screen width when the object is initialized
+</p>
+<p>
+  <img id="responsive" src="images/small/image1.png" data-zoom-image="images/large/image1.jpg"/>
+</p>
+
+<script>
+$(function () {
+  $("#responsive").elevateZoom({
+    tint:true, 
+    tintColour:'#0F0', 
+    tintOpacity:0.5,
+    respond: [
+      {
+        range: '600-799',
+        tintColour: '#F00'
+      },
+      {
+        range: '800-1199',
+        tintColour: '#00F'
+      },
+    ]
+  }); 
+})
+</script>
+
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -121,6 +121,10 @@ $(function () {
         range: '800-1199',
         tintColour: '#00F'
       },
+      {
+        range: '100-599',
+        enabled: false
+      }
     ]
   }); 
 })

--- a/js/jquery.elevatezoom.js
+++ b/js/jquery.elevatezoom.js
@@ -33,6 +33,8 @@ if ( typeof Object.create !== 'function' ) {
 
 				self.options = $.extend( {}, $.fn.elevateZoom.options, self.responsiveConfig(options || {}) );
 
+				if (!self.options.enabled) return;
+				
 				//TINT OVERRIDE SETTINGS
 				if(self.options.tint) {
 					self.options.lensColour = "none", //colour of the lens background
@@ -1720,6 +1722,7 @@ if ( typeof Object.create !== 'function' ) {
 			debug: false,
 			easing: false,
 			easingAmount: 12,
+			enabled: true,
 			gallery: false,
 			galleryActiveClass: "zoomGalleryActive",
 			imageCrossfade: false,

--- a/js/jquery.elevatezoom.js
+++ b/js/jquery.elevatezoom.js
@@ -31,7 +31,7 @@ if ( typeof Object.create !== 'function' ) {
 
 				self.imageSrc = self.$elem.data("zoom-image") ? self.$elem.data("zoom-image") : self.$elem.attr("src");
 
-				self.options = $.extend( {}, $.fn.elevateZoom.options, options );
+				self.options = $.extend( {}, $.fn.elevateZoom.options, self.responsiveConfig(options || {}) );
 
 				//TINT OVERRIDE SETTINGS
 				if(self.options.tint) {
@@ -1673,6 +1673,26 @@ if ( typeof Object.create !== 'function' ) {
       	var self = this;
 				if(value == 'enable'){self.options.zoomEnabled = true;}
 				if(value == 'disable'){self.options.zoomEnabled = false;}
+			},
+			responsiveConfig: function (options) {
+				if (options.respond && options.respond.length > 0) {
+					return $.extend({}, options, this.configByScreenWidth(options));
+				}
+				return options;
+			},
+			configByScreenWidth: function (options) {
+				var screenWidth = $(window).width();
+
+				var config = $.grep(options.respond, function (item) {
+					var range = item.range.split('-');	
+					return (screenWidth >= range[0]) && (screenWidth <= range[1])
+				});
+
+				if (config.length > 0) {
+					return config[0]
+				} else {
+					return options;
+				}
 			}
 	};
 
@@ -1720,6 +1740,7 @@ if ( typeof Object.create !== 'function' ) {
 			onImageSwapComplete: $.noop,
 			onZoomedImageLoaded: function() {},
 			preloading: 1, //by default, load all the images, if 0, then only load images after activated (PLACEHOLDER FOR NEXT VERSION)
+			respond: [],
 			responsive:true,
 			scrollZoom: false, //allow zoom on mousewheel, true to activate
 			scrollZoomIncrement: 0.1,  //steps of the scrollzoom


### PR DESCRIPTION
Not truly "Responsive", but allows you to set configuration based off screen width when the elevatezoom object is instantiated. Also adds the ability to disable the plugin altogether.

```javascript
$(function () {
  $("#responsive").elevateZoom({
    tint:true, 
    tintColour:'#0F0', 
    tintOpacity:0.5,
    respond: [
      {
        range: '600-799',
        tintColour: '#F00'
      },
      {
        range: '800-1199',
        tintColour: '#00F'
      },
      {
        range: '100-599',
        enabled: false
      }
    ]
  }); 
})
```